### PR TITLE
Fix var to local

### DIFF
--- a/proxmox/lxc/main.tf
+++ b/proxmox/lxc/main.tf
@@ -36,7 +36,7 @@ resource "proxmox_lxc" "basic" {
   network {
     name   = "eth0"
     bridge = "vmbr0"
-    ip     = var.ip_with_cidr
+    ip     = local.ip_with_cidr
     gw     = var.default_gateway
   }
 


### PR DESCRIPTION
This PR fixes error:
```
│ An input variable with the name "ip_with_cidr" has not been declared. This
│ variable can be declared with a variable "ip_with_cidr" {} block.
```
Due to bad variable reference.